### PR TITLE
Redirect to recently created project upon creation

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -31,7 +31,7 @@ class ProjectsController < ApplicationController
     @project = Project.new(projects_params)
     if @project.save
       flash[:success] = "Project created!"
-      redirect_to "/projects"
+      redirect_to project_path(@project.id)
     else
       flash.now[:error] = @project.errors.full_messages
       render :new

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -62,8 +62,9 @@ RSpec.describe ProjectsController, type: :controller do
 
       it "redirects to the new project" do
         post :create, params: {project: valid_params}
+        created_project = Project.last
 
-        expect(response).to redirect_to "/projects"
+        expect(response).to redirect_to "/projects/#{created_project.id}"
       end
     end
 


### PR DESCRIPTION
# Description

Updates project creation to redirect to recently created project instead of redirecting to "/projects".

See [trello card](https://trello.com/c/dWvSMEmk/2-as-a-user-i-want-to-be-taken-to-the-parent-project-after-creating-a-sub-project)