### PR TITLE
Redirect to parent project after creating subproject

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -28,10 +28,10 @@ class ProjectsController < ApplicationController
   end
 
   def create
-    @project = Project.new(projects_params)
+    @project = Project.new(project_params)
     if @project.save
       flash[:success] = "Project created!"
-      redirect_to project_path(@project.id)
+      redirect_to project_path(@project.parent_id || @project.id)
     else
       flash.now[:error] = @project.errors.full_messages
       render :new
@@ -52,7 +52,7 @@ class ProjectsController < ApplicationController
   end
 
   def update
-    if @project.update(projects_params)
+    if @project.update(project_params)
       respond_to do |format|
         format.html do
           flash[:success] = "Project updated!"
@@ -78,7 +78,7 @@ class ProjectsController < ApplicationController
     @project = Project.find(params[:id] || params[:project_id])
   end
 
-  def projects_params
+  def project_params
     params.require(:project).permit(:title, :status, :parent_id)
   end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -68,6 +68,22 @@ RSpec.describe ProjectsController, type: :controller do
       end
     end
 
+    context "for a subproject" do
+      let(:sub_project_valid_params) { attributes_for(:project, parent_id: project.id) }
+
+      it "creates a new sub project" do
+        expect {
+          post :create, params: {project: sub_project_valid_params}
+        }.to change(Project, :count).by(1)
+      end
+
+      it "redirects to the parent project" do
+        post :create, params: {project: sub_project_valid_params}
+
+        expect(response).to redirect_to "/projects/#{project.id}"
+      end
+    end
+
     context "with invalid attributes" do
       let(:invalid_attributes) { {title: ""} }
 


### PR DESCRIPTION
# Description

After creating a subproject, it redirects to the parent project's page. See [trello card](https://trello.com/c/dWvSMEmk/2-as-a-user-i-want-to-be-taken-to-the-parent-project-after-creating-a-sub-project)